### PR TITLE
Docs - Add 'run' to npm install-all command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ upstream	https://github.com/Aman-Codes/pennamechooser (push)
 4. Once the remote is set, install all the necessary dependencies by the following command:
 
 ```sh
-npm install-all
+npm run install-all
 ```
 
 ### Run locally


### PR DESCRIPTION
## Proposed changes

When setting up this project to work on a different issue, I followed the README and ran in to problems with the `npm install-all` command. As it is a custom command, I am pretty sure it has to be `npm run install-all` as this is what worked for me.

## Types of changes

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (Documentation content changed)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
