### PR TITLE
Remove duplicate of 'wrapper a' class in frontend/src/App.css

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -16,7 +16,24 @@
   overflow-x: hidden;
 }
 .wrapper a {
+  border: 1px solid black;
   color: white;
+  text-align: center;
+  display: -ms-grid;
+  display: grid;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -ms-flex-line-pack: center;
+      align-content: center;
+  border-radius: 1em;
+  -webkit-box-shadow: 0 0 20px rgb(0 0 0 / 19%);
+          box-shadow: 0 0 20px rgb(0 0 0 / 19%);
+  font-weight: bolder;
+  letter-spacing: 2px;
+  font-size: 20px;
+  -webkit-animation: breathing1 1s ease-in-out infinite normal backwards;
+          animation: breathing1 1s ease-in-out infinite normal backwards;
 }
 .wrapper a:nth-child(2) {
   -ms-grid-column: 3;
@@ -83,25 +100,6 @@
           animation: breathing2 1s ease-in-out infinite normal backwards;
 }
 .wrapper a:nth-child(13) {
-  -webkit-animation: breathing1 1s ease-in-out infinite normal backwards;
-          animation: breathing1 1s ease-in-out infinite normal backwards;
-}
-.wrapper a {
-  border: 1px solid black;
-  text-align: center;
-  display: -ms-grid;
-  display: grid;
-  -webkit-box-pack: center;
-      -ms-flex-pack: center;
-          justify-content: center;
-  -ms-flex-line-pack: center;
-      align-content: center;
-  border-radius: 1em;
-  -webkit-box-shadow: 0 0 20px rgb(0 0 0 / 19%);
-          box-shadow: 0 0 20px rgb(0 0 0 / 19%);
-  font-weight: bolder;
-  letter-spacing: 2px;
-  font-size: 20px;
   -webkit-animation: breathing1 1s ease-in-out infinite normal backwards;
           animation: breathing1 1s ease-in-out infinite normal backwards;
 }


### PR DESCRIPTION
## Issue that this pull request solves

N/A

## Proposed changes

The .wrapper a class was declared twice in frontend/src/App.css. Merged both of them together in this PR.

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots

N/A

## Other information

N/A
